### PR TITLE
Replace Evil Wildcards with Explicit Versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,10 @@ authors = ["Sébastien Nadon <sn@sebastiennadon.com>"]
 watch = ["handlebars-iron/watch"]
 
 [dependencies]
-iron = "*"
-mount = "*"
-staticfile = "*"
-time = "*"
-router = "*"
-iron-login = "*"
-handlebars-iron = "*"
+iron = "0.3.0"
+mount = "0.1.0"
+staticfile = "0.2.0"
+time = "0.1.35"
+router = "0.1.1"
+iron-login = "0.4.1"
+handlebars-iron = "0.15.1"


### PR DESCRIPTION
Cargo will actually treat those as e.g. `^0.4.1`, so it will fetch SemVer compatible updates (`^0.4.1` → `≥0.4.1 AND <0.5.0`, `1.2.3` → `≥1.2.3 AND <2.0.0`).